### PR TITLE
Enable Sender in websocket metadata

### DIFF
--- a/macros/src/auto_args.rs
+++ b/macros/src/auto_args.rs
@@ -642,4 +642,3 @@ wrap_with_trailing!(4, A, B, C, D);
 wrap_with_trailing!(3, A, B, C);
 wrap_with_trailing!(2, A, B);
 wrap_with_trailing!(1, A);
-

--- a/ws/src/lib.rs
+++ b/ws/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 use jsonrpc_core as core;
 
 pub use self::error::{Error, ErrorKind, Result};
-pub use self::metadata::{RequestContext, MetaExtractor, NoopExtractor};
+pub use self::metadata::{RequestContext, MetaExtractor, NoopExtractor, Sender};
 pub use self::session::{RequestMiddleware, MiddlewareAction};
 pub use self::server::{CloseHandle, Server};
 pub use self::server_builder::ServerBuilder;

--- a/ws/src/metadata.rs
+++ b/ws/src/metadata.rs
@@ -25,7 +25,8 @@ impl Sender {
 		}
 	}
 
-	fn check_active(&self) -> error::Result<()> {
+	/// Checks whether connection is still active
+	pub fn check_active(&self) -> error::Result<()> {
 		if self.active.load(atomic::Ordering::SeqCst) {
 			Ok(())
 		} else {


### PR DESCRIPTION
... and use of `check_active` to determine if client connection is still open.